### PR TITLE
Do not remove fixed-supported class on scroll on iPad

### DIFF
--- a/src/fixedfixed.js
+++ b/src/fixedfixed.js
@@ -4,7 +4,8 @@
 	var htmlclass = "fixed-supported",
 		el = w.document.createElement( "div" ),
 		ua = w.navigator.userAgent,
-		docEl = w.document.documentElement;
+		docEl = w.document.documentElement,
+		allowRemove = !( ua.match( /iPad; CPU OS 8|iPhone; CPU OS 8/ ) && ua.indexOf("AppleWebKit") >= 0 );
 
 	// fix the test element
 	el.style.position = "fixed";
@@ -20,7 +21,7 @@
 
 			w.document.body.insertBefore( el, w.document.body.firstChild );
 
-			if( !el.getBoundingClientRect || el.getBoundingClientRect().top !== 0 ){
+			if(allowRemove && ( !el.getBoundingClientRect || el.getBoundingClientRect().top !== 0 )){
 				// Fixed is not working or can't be tested
 				docEl.className = docEl.className.replace( htmlclass, "" );
 			}
@@ -47,9 +48,7 @@
 		// Opera Mini
 		!( w.operamini && ({}).toString.call( w.operamini ) === "[object OperaMini]" ) ||
 		// Firefox Mobile less than version 6
-		!( ua.match( /Fennec\/([0-9]+)/ ) && RegExp.$1 < 6 ) ||
-		// iOS 8 
-		!( ua.match( /iPad; CPU OS 8|iPhone; CPU OS 8/ ) && ua.indexOf("AppleWebKit") >= 0 )
+		!( ua.match( /Fennec\/([0-9]+)/ ) && RegExp.$1 < 6 )
 		// If necessary, add the other untestable browsers here...
 	){
 		//add the HTML class for now.


### PR DESCRIPTION
Sorry for the noise. Issue is not removing `fixed-supported` but rather it was removed when scrolling. This code was what was in @sts14 's original PR. Hopefully this will work.
